### PR TITLE
Ensure searchforward options honors boolean 'false' setting

### DIFF
--- a/lib/rex/exploitation/omelet.rb
+++ b/lib/rex/exploitation/omelet.rb
@@ -84,7 +84,7 @@ class Omelet
 
       eggsize       = opts[:eggsize] || 123
       eggtag        = opts[:eggtag] || "00w"
-      searchforward = opts[:searchforward] || true
+      searchforward = opts[:searchforward].nil? ? true : opts[:searchforward]
       reset         = opts[:reset]
       startreg      = opts[:startreg]
       usechecksum   = opts[:checksum]


### PR DESCRIPTION
See Metasploit Framework issue 7452:

https://github.com/rapid7/metasploit-framework/issues/7452
Signed-off-by: Pearce Barry pearce_barry@rapid7.com

This fix tested fine for cases where opts[:searchforward]:
- isn't defined at all
- is set to false
- is set to true

Totally open to discussion around my use of a ternary conditional (and other suggestions that might be preferred).
