### PR TITLE
Fix heap_spray method's return value type

### DIFF
--- a/lib/rex/exploitation/js/memory.rb
+++ b/lib/rex/exploitation/js/memory.rb
@@ -54,7 +54,7 @@ class Memory
         'Symbols' => {
           'Variables' => %w{ index heapSprayAddr_hi heapSprayAddr_lo retSlide heapBlockCnt }
         }
-      }).obfuscate
+      })
   end
 
   def self.explib2


### PR DESCRIPTION
The heap_spray method returns a string after calling obfuscate, but it should be returning Rex::Exploitation::ObfuscateJS instead.

To test, you can do this:

```ruby
o = ::Rex::Exploitation::ObfuscateJS.new(%Q|var someVar = "hello, world"; alert(someVar)|)
```

Inspect the object:

```ruby
o.class
```

And that should return Rex::Exploitation::ObfuscateJS.

If you do this:

```ruby
"#{o}"
```

It should return the JavaScript string:

```ruby
"alert(\"hello, world\")"
```

And then if you call obfuscate:

```ruby
o.obfuscate('Symbols' => {'Variables'=>['someVar']}, 'Strings' => true)
```

It should give you the obfuscated JavaScript

And then if you call the #sym method for the variable ```someVar```

```ruby
o.sym('someVar')
```

It should tell you the obfuscated name of ```someVar```