### PR TITLE
Add a hex_double_quoted option to the echo cmdstager

### DIFF
--- a/lib/rex/exploitation/cmdstager/echo.rb
+++ b/lib/rex/exploitation/cmdstager/echo.rb
@@ -10,9 +10,10 @@ module Exploitation
 class CmdStagerEcho < CmdStagerBase
 
   ENCODINGS = {
-    'hex'          => "\\\\x",
-    'octal'        => "\\\\",
-    'hex_quoted'   => "\\x",
+    'hex'                 => "\\\\x",
+    'octal'               => "\\\\",
+    'hex_quoted'          => "\\x",
+    'hex_single_quoted'   => "\\x",
   }
 
   def initialize(exe)
@@ -98,6 +99,8 @@ class CmdStagerEcho < CmdStagerBase
       cmd << @cmd_start
       if opts[:enc_format] == 'hex_quoted'
         cmd << %Q{"#{p}"}
+      elsif opts[:enc_format] == 'hex_single_quoted'
+        cmd << %Q{'#{p}'}
       else
         cmd << p
       end
@@ -154,7 +157,7 @@ class CmdStagerEcho < CmdStagerBase
       while (fixed_part.length > 0 && fixed_part[-5, @prefix.length] != @prefix)
         fixed_part.chop!
       end
-    when 'hex_quoted'
+    when 'hex_quoted', 'hex_single_quoted'
       while (fixed_part.length > 0 && fixed_part[-4, @prefix.length] != @prefix)
         fixed_part.chop!
       end

--- a/lib/rex/exploitation/cmdstager/echo.rb
+++ b/lib/rex/exploitation/cmdstager/echo.rb
@@ -10,8 +10,9 @@ module Exploitation
 class CmdStagerEcho < CmdStagerBase
 
   ENCODINGS = {
-    'hex'   => "\\\\x",
-    'octal' => "\\\\"
+    'hex'          => "\\\\x",
+    'octal'        => "\\\\",
+    'hex_quoted'   => "\\x",
   }
 
   def initialize(exe)
@@ -55,6 +56,9 @@ class CmdStagerEcho < CmdStagerBase
 
     @cmd_end   = ">>#{@tempdir}#{@var_elf}"
     xtra_len = @cmd_start.length + @cmd_end.length
+    if opts[:enc_format].to_s =~ /quoted/
+      xtra_len += 2
+    end
     opts.merge!({ :extra => xtra_len })
 
     @prefix = opts[:prefix] || ENCODINGS[opts[:enc_format]]
@@ -92,7 +96,11 @@ class CmdStagerEcho < CmdStagerBase
     parts.map do |p|
       cmd = ''
       cmd << @cmd_start
-      cmd << p
+      if opts[:enc_format] == 'hex_quoted'
+        cmd << %Q{"#{p}"}
+      else
+        cmd << p
+      end
       cmd << @cmd_end
       cmd
     end
@@ -144,6 +152,10 @@ class CmdStagerEcho < CmdStagerBase
     case opts[:enc_format]
     when 'hex'
       while (fixed_part.length > 0 && fixed_part[-5, @prefix.length] != @prefix)
+        fixed_part.chop!
+      end
+    when 'hex_quoted'
+      while (fixed_part.length > 0 && fixed_part[-4, @prefix.length] != @prefix)
         fixed_part.chop!
       end
     when 'octal'

--- a/lib/rex/exploitation/cmdstager/echo.rb
+++ b/lib/rex/exploitation/cmdstager/echo.rb
@@ -12,7 +12,7 @@ class CmdStagerEcho < CmdStagerBase
   ENCODINGS = {
     'hex'                 => "\\\\x",
     'octal'               => "\\\\",
-    'hex_quoted'          => "\\x",
+    'hex_double_quoted'   => "\\x",
     'hex_single_quoted'   => "\\x",
   }
 
@@ -97,7 +97,7 @@ class CmdStagerEcho < CmdStagerBase
     parts.map do |p|
       cmd = ''
       cmd << @cmd_start
-      if opts[:enc_format] == 'hex_quoted'
+      if opts[:enc_format] == 'hex_double_quoted'
         cmd << %Q{"#{p}"}
       elsif opts[:enc_format] == 'hex_single_quoted'
         cmd << %Q{'#{p}'}
@@ -157,7 +157,7 @@ class CmdStagerEcho < CmdStagerBase
       while (fixed_part.length > 0 && fixed_part[-5, @prefix.length] != @prefix)
         fixed_part.chop!
       end
-    when 'hex_quoted', 'hex_single_quoted'
+    when /hex_.*_quoted/
       while (fixed_part.length > 0 && fixed_part[-4, @prefix.length] != @prefix)
         fixed_part.chop!
       end

--- a/spec/lib/rex/exploitation/cmdstager/echo_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/echo_spec.rb
@@ -47,4 +47,17 @@ RSpec.describe Rex::Exploitation::CmdStagerEcho do
     end
   end
 
+  describe '#generate_hex_single_quoted_linemax_32' do
+    it "returns an array of commands, single quoted, split to 32 byte chunks" do
+      result = cmd_stager.generate(linemax: 32,
+                                   enc_format: :hex_single_quoted)
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+      expect(result.size).to be > 1
+      expect(result[1].size).to be <= 32
+      # This is pretty specific to my starting exe value up there.
+      expect(result[1]).to start_with("echo -en '\\x41\\x41'>>/tmp/")
+    end
+  end
+
 end

--- a/spec/lib/rex/exploitation/cmdstager/echo_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/echo_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe Rex::Exploitation::CmdStagerEcho do
     end
   end
 
-  describe '#generate_hex_quoted_linemax_32' do
-    it "returns an array of commands, split to 32 byte chunks" do
+  describe '#generate_hex_double_quoted_linemax_32' do
+    it "returns an array of commands, double quoted, split to 32 byte chunks" do
       result = cmd_stager.generate(linemax: 32,
-                                   enc_format: :hex_quoted)
+                                   enc_format: :hex_double_quoted)
       expect(result).to be_kind_of(Array)
       expect(result).to_not be_empty
       expect(result.size).to be > 1

--- a/spec/lib/rex/exploitation/cmdstager/echo_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/echo_spec.rb
@@ -5,7 +5,7 @@ require 'rex/exploitation/cmdstager'
 
 RSpec.describe Rex::Exploitation::CmdStagerEcho do
 
-  let(:exe) { "MZ" }
+  let(:exe) { "MZAAAAAAAA" }
 
   subject(:cmd_stager) do
     described_class.new(exe)
@@ -20,9 +20,30 @@ RSpec.describe Rex::Exploitation::CmdStagerEcho do
   describe '#generate' do
     it "returns an array of commands" do
       result = cmd_stager.generate
-
       expect(result).to be_kind_of(Array)
       expect(result).to_not be_empty
+    end
+  end
+
+  describe '#generate_linemax_64' do
+    it "returns an array of commands" do
+      result = cmd_stager.generate(linemax: 64)
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+      expect(result.size).to be > 1
+    end
+  end
+
+  describe '#generate_hex_quoted_linemax_32' do
+    it "returns an array of commands" do
+      result = cmd_stager.generate(linemax: 32,
+                                   enc_format: :hex_quoted)
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+      expect(result.size).to be > 1
+      expect(result[1].size).to be <= 32
+      # This is pretty specific to my starting exe value up there.
+      expect(result[1]).to start_with('echo -en "\x41\x41">>/tmp/')
     end
   end
 

--- a/spec/lib/rex/exploitation/cmdstager/echo_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/echo_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Rex::Exploitation::CmdStagerEcho do
   end
 
   describe '#generate_linemax_64' do
-    it "returns an array of commands" do
+    it "returns an array of commands, split to 64 byte chunks" do
       result = cmd_stager.generate(linemax: 64)
       expect(result).to be_kind_of(Array)
       expect(result).to_not be_empty
@@ -35,7 +35,7 @@ RSpec.describe Rex::Exploitation::CmdStagerEcho do
   end
 
   describe '#generate_hex_quoted_linemax_32' do
-    it "returns an array of commands" do
+    it "returns an array of commands, split to 32 byte chunks" do
       result = cmd_stager.generate(linemax: 32,
                                    enc_format: :hex_quoted)
       expect(result).to be_kind_of(Array)


### PR DESCRIPTION
This appears to be needed for rapid7/metasploit-framework#7626

Also, might be nice to have in general, since it can help keep the
stager size down.

This PR includes some updated spec's to exercise some of the functionality a little better, but of course, my spec writing is still quite innocent and child-like.
