### PR TITLE
Ignore local temp files, OSX junk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@
 /tmp/
 /.ruby-version
 /.ruby-gemset
+.DS_Store
+*.swp
+*.orig
+*.rej
+*~


### PR DESCRIPTION
This just leaves out the usual junk files you never want to check in:

* .DS_Store
* *.swp
* *.orig
* *.rej
* *~