### PR TITLE
Update FF versions from 36 to 51

### DIFF
--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -63,6 +63,12 @@ os_detect.getVersion = function(){
 		return input.type == input_type;
 	}
 
+	var syntax_is_valid = function(code) {
+		try { eval(code); return true;}
+		catch (err) {}
+		return false;
+	}
+
 	//--
 	// Client
 	//--
@@ -221,7 +227,59 @@ os_detect.getVersion = function(){
 		// Thanks to developer.mozilla.org "Firefox for developers" series for most
 		// of these.
 		// Release changelogs: http://www.mozilla.org/en-US/firefox/releases/
-		if ('closest' in Element.prototype) {
+		if ('Symbol' in window && 'toStringTag' in window.Symbol) {
+			ua_version = '51.0';
+		}
+		else if ('Object' in window && 'getOwnPropertyDescriptors' in window.Object) {
+			ua_version = '50.0';
+		}
+		else if ('SpeechSynthesis' in window) { 
+			ua_version = '49.0';
+		}
+		else if ('padStart' in String.prototype) {
+			ua_version = '48.0';
+		}
+		else if ('TextTrack' in window &&
+			     'oncuechange' in window.TextTrack.prototype) {
+			ua_version = '47.0';
+		}
+		else if ('elementsFromPoint' in document) {
+			ua_version = '46.0';
+		}
+		else if (syntax_is_valid('class A {}')) {
+			ua_version = '45.0';
+		}
+		else if ('serviceWorker' in navigator) {
+			ua_version = '44.0';
+		}
+		else if (css_is_valid('hyphens', 'hyphens', 'auto')) {
+			ua_version = '43.0';
+		}
+		else if (typeof(ImageBitmap) == 'function') {
+			ua_version = '42.0';
+		}
+		else if (typeof(MessageChannel) == 'function') {
+			ua_version = '41.0';
+		}
+		else if (typeof(AudioContext) == 'function' &&
+			     typeof(new AudioContext().createBufferSource().detune) == 'object') {
+			ua_version = '40.0';
+		}
+		else if (css_is_valid('scroll-snap-points-x', 'scrollSnapPointsX', 'unset')) {
+			ua_version = '39.0';
+		}
+		else if ('createElement' in document &&
+		         document.createElement('picture') &&
+		         document.createElement('picture').constructor === window['HTMLPictureElement']) {
+			ua_version = '38.0';
+		}
+		else if (css_is_valid('display', 'display', 'contents')) {
+			ua_version = '37.0';
+		}
+		else if (css_is_valid('isolation', 'isolation', 'isolate')) {
+			ua_version = '36.0';
+		}
+		else if ('closest' in Element.prototype) {
 			ua_version = '35.0';
 		} else if ('matches' in Element.prototype) {
 			ua_version = '34.0';

--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -249,7 +249,7 @@ os_detect.getVersion = function(){
 		else if (syntax_is_valid('class A {}')) {
 			ua_version = '45.0';
 		}
-		else if ('serviceWorker' in navigator) {
+		else if ('Symbol' in window && 'toPrimitive' in Symbol) {
 			ua_version = '44.0';
 		}
 		else if (css_is_valid('hyphens', 'hyphens', 'auto')) {


### PR DESCRIPTION
This updates the os.js file to support Mozilla Firefox versions from 36 to 51.

Verification

- [x] Make sure http://msfsinn3rtest.getforge.io/test.html is up
- [x] Go to http://browsershots.org/
- [x] Only select Firefox versions from 36 to 51
- [x] Submit http://msfsinn3rtest.getforge.io/test.html so that all these snapshots can test
- [x] Verify that each snapshot is printing the correct FF version