### PR TITLE
Add bourne BusyBox base64 decoder

### DIFF
--- a/lib/rex/exploitation/cmdstager/bourne.rb
+++ b/lib/rex/exploitation/cmdstager/bourne.rb
@@ -72,6 +72,7 @@ class CmdStagerBourne < CmdStagerBase
   #
   def generate_cmds_decoder(opts)
     decoders = [
+      "base64 -d -",
       "base64 --decode -",
       "openssl enc -d -A -base64 -in /dev/stdin",
       "python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());'",


### PR DESCRIPTION
Prioritized '-d' option for portability (BusyBox over macOS)