### PR TITLE
Add CmdStager option to skip command compression

### DIFF
--- a/lib/rex/exploitation/cmdstager/base.rb
+++ b/lib/rex/exploitation/cmdstager/base.rb
@@ -129,6 +129,9 @@ class CmdStagerBase
 
     concat = opts[:concat_operator] || cmd_concat_operator
 
+    # Skip command compression if desired, returning individual commands
+    return cmds if opts[:nocompress]
+
     # We cannot compress commands if there is no way to combine commands on
     # a single line.
     return cmds unless concat


### PR DESCRIPTION
If `opts[:nocompress]` is specified, command compression (concatenation) will not be performed, and the individual commands will be returned.

Note that `opts[:linemax]` is not respected if this option is set or if the concatenation operator is missing. This will need to be fixed.