### PR TITLE
Rename opts[:nocompress] to opts[:noconcat]

### DIFF
--- a/lib/rex/exploitation/cmdstager/base.rb
+++ b/lib/rex/exploitation/cmdstager/base.rb
@@ -129,8 +129,8 @@ class CmdStagerBase
 
     concat = opts[:concat_operator] || cmd_concat_operator
 
-    # Skip command compression if desired, returning individual commands
-    return cmds if opts[:nocompress]
+    # Skip command concatentation if desired, returning individual commands
+    return cmds if opts[:noconcat]
 
     # We cannot compress commands if there is no way to combine commands on
     # a single line.


### PR DESCRIPTION
It makes more sense.