### PR TITLE
bump deps, point to upstream metasm fix branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,7 @@ group: stable
 cache: bundler
 language: ruby
 rvm:
-  - 2.3.3
+  - '2.3.8'
+  - '2.4.5'
+  - '2.5.5'
+  - '2.6.2'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
 
+# use custom metasm until fix for 2.5 is released
+gem 'metasm', git: "https://github.com/rapid7/metasm", branch: "ruby_2_5_compat"
+
 # Specify your gem's dependencies in rex-exploitation.gemspec
 gemspec

--- a/rex-exploitation.gemspec
+++ b/rex-exploitation.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.2.0'
+  spec.required_ruby_version = '>= 2.3.0'
 
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
 
   spec.add_runtime_dependency 'rex-text'
   spec.add_runtime_dependency 'rex-arch'


### PR DESCRIPTION
Looks like we might need to bump metasm here as well to grab the latest fixes.