### PR TITLE
Fix rex-arch constant usage

### DIFF
--- a/lib/rex/exploitation/egghunter.rb
+++ b/lib/rex/exploitation/egghunter.rb
@@ -36,7 +36,7 @@ class Egghunter
     Alias = "win"
 
     module X86
-      Alias = ARCH_X86
+      Alias = Rex::Arch::ARCH_X86
 
       #
       # The egg hunter stub for win/x86.
@@ -250,7 +250,7 @@ EOS
     Alias = "linux"
 
     module X86
-      Alias = ARCH_X86
+      Alias = Rex::Arch::ARCH_X86
 
       #
       # The egg hunter stub for linux/x86.

--- a/lib/rex/exploitation/omelet.rb
+++ b/lib/rex/exploitation/omelet.rb
@@ -25,7 +25,7 @@ class Omelet
     Alias = "win"
 
     module X86
-      Alias = ARCH_X86
+      Alias = Rex::Arch::ARCH_X86
 
       #
       # The hunter stub for win/x86.

--- a/spec/lib/rex/exploitation/egghunter_spec.rb
+++ b/spec/lib/rex/exploitation/egghunter_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require 'rex/exploitation/egghunter'
+
+RSpec.describe Rex::Exploitation::Egghunter do
+
+  describe '#new' do
+    it 'returns an Egghunter object' do
+      expect(described_class.new("x86")).to be_a(Rex::Exploitation::Egghunter)
+    end
+  end
+end

--- a/spec/lib/rex/exploitation/omelet_spec.rb
+++ b/spec/lib/rex/exploitation/omelet_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require 'rex/exploitation/omelet'
+
+RSpec.describe Rex::Exploitation::Omelet do
+
+  describe '#new' do
+    it 'returns an Omelet object' do
+      expect(described_class.new("x86")).to be_a(Rex::Exploitation::Omelet)
+    end
+  end
+end


### PR DESCRIPTION
Updated the usage of some `rex-arch` constants that worked when this gem was included within framework but as a standlone gem it was broken
Also added some test to verify the fixes
