### PR TITLE
Update for ruby 3 support

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,56 @@
+name: Verify
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    runs-on: ubuntu-16.04
+    timeout-minutes: 40
+
+    strategy:
+      fail-fast: true
+      matrix:
+        ruby:
+          - 2.6
+          - 2.7
+          - 3.0
+        test_cmd:
+          - bundle exec rspec
+
+    env:
+      RAILS_ENV: test
+
+    name: Ruby ${{ matrix.ruby }} - ${{ matrix.test_cmd }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: Setup bundler
+        run: |
+          gem install bundler
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: ${{ matrix.test_cmd }}
+        run: |
+          echo "${CMD}"
+          bash -c "${CMD}"
+        env:
+          CMD: ${{ matrix.test_cmd }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-group: stable
-cache: bundler
-language: ruby
-rvm:
-  - 2.7.2

--- a/rex-exploitation.gemspec
+++ b/rex-exploitation.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 
+  spec.add_runtime_dependency 'rexml'
   spec.add_runtime_dependency 'rex-text'
   spec.add_runtime_dependency 'rex-arch'
   spec.add_runtime_dependency 'rex-encoder'


### PR DESCRIPTION
Adding `rexml` dependency - https://github.com/rapid7/metasploit-framework/issues/14666

Updating to work with Github actions:

![image](https://user-images.githubusercontent.com/60357436/106926613-2bac2280-6709-11eb-8fce-34eaddee2ac1.png)
