### PR TITLE
Update spec tests

### DIFF
--- a/spec/lib/rex/exploitation/cmdstager/base_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/base_spec.rb
@@ -23,4 +23,16 @@ RSpec.describe Rex::Exploitation::CmdStagerBase do
     end
   end
 
+  describe '#compress_commands' do
+    it "raises when cmd length exceeds :linemax" do
+      expect {
+        cmd_stager.compress_commands(
+          ["#{Rex::Text.rand_text_alphanumeric(10)}"],
+          concat_operator: ';',
+          linemax: 5
+        )
+      }.to raise_error(RuntimeError)
+    end
+  end
+
 end

--- a/spec/lib/rex/exploitation/cmdstager/bourne_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/bourne_spec.rb
@@ -26,4 +26,19 @@ RSpec.describe Rex::Exploitation::CmdStagerBourne do
     end
   end
 
+  describe '#generate_nodelete' do
+    it "returns an array of commands without rm" do
+      result = cmd_stager.generate(
+        nodelete: true
+      )
+
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+
+      for command in result
+        expect(command).to_not include('rm -f ')
+      end
+    end
+  end
+
 end

--- a/spec/lib/rex/exploitation/cmdstager/certutil_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/certutil_spec.rb
@@ -20,4 +20,19 @@ RSpec.describe Rex::Exploitation::CmdStagerCertutil do
     end
   end
 
+  describe '#generate_nodelete' do
+    it "returns an array of commands without rm" do
+      result = cmd_stager.generate(
+        nodelete: true
+      )
+
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+
+      for command in result
+        expect(command).to_not include('rm -f ')
+      end
+    end
+  end
+
 end

--- a/spec/lib/rex/exploitation/cmdstager/curl_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/curl_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe Rex::Exploitation::CmdStagerCurl do
     described_class.new(exe)
   end
 
+  describe "#http?" do
+    it "returns true" do
+      expect(cmd_stager.http?)
+    end
+  end
+
+  describe "#user_agent" do
+    it "returns a known user agent match" do
+      expect(cmd_stager.user_agent).to be_kind_of(Regexp)
+    end
+  end
+
   describe '#cmd_concat_operator' do
     it "returns ;" do
       expect(cmd_stager.cmd_concat_operator).to eq(';')
@@ -18,13 +30,19 @@ RSpec.describe Rex::Exploitation::CmdStagerCurl do
   end
 
   describe '#generate' do
+    it "raises when missing :payload_uri" do
+      expect { cmd_stager.generate }.to raise_error(StandardError)
+    end
+
     it "returns an array of commands" do
       result = cmd_stager.generate(payload_uri: "http://127.0.0.1/#{Rex::Text.rand_text_alphanumeric(10)}")
 
       expect(result).to be_kind_of(Array)
       expect(result).to_not be_empty
     end
+  end
 
+  describe '#generate_nospace' do
     it "returns an array of commands without spaces" do
       result = cmd_stager.generate(
         payload_uri: "http://127.0.0.1/#{Rex::Text.rand_text_alphanumeric(10)}",

--- a/spec/lib/rex/exploitation/cmdstager/debug_asm_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/debug_asm_spec.rb
@@ -32,4 +32,20 @@ RSpec.describe Rex::Exploitation::CmdStagerDebugAsm do
     end
   end
 
+  describe '#generate_nodelete' do
+    it "returns an array of commands without del" do
+      result = cmd_stager.generate(
+        decoder: File.join(Rex::Exploitation::DATA_DIR, "exploits", "cmdstager", "debug_write"),
+        nodelete: true
+      )
+
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+
+      for command in result
+        expect(command).to_not include('del ')
+      end
+    end
+  end
+
 end

--- a/spec/lib/rex/exploitation/cmdstager/debug_write_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/debug_write_spec.rb
@@ -32,4 +32,20 @@ RSpec.describe Rex::Exploitation::CmdStagerDebugWrite do
     end
   end
 
+  describe '#generate_nodelete' do
+    it "returns an array of commands without del" do
+      result = cmd_stager.generate(
+        decoder: File.join(Rex::Exploitation::DATA_DIR, "exploits", "cmdstager", "debug_write"),
+        nodelete: true
+      )
+
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+
+      for command in result
+        expect(command).to_not include('del ')
+      end
+    end
+  end
+
 end

--- a/spec/lib/rex/exploitation/cmdstager/echo_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/echo_spec.rb
@@ -23,6 +23,20 @@ RSpec.describe Rex::Exploitation::CmdStagerEcho do
       expect(result).to be_kind_of(Array)
       expect(result).to_not be_empty
     end
+
+    it "raises when :enc_format is not a valid encoding" do
+      expect {
+        cmd_stager.generate(enc_format: 'invalid')
+      }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe '#generate_linemax_too_small' do
+    it "raises when :linemax is too small to contain min_part_size" do
+      expect {
+        cmd_stager.generate(linemax: 5)
+      }.to raise_error(RuntimeError)
+    end
   end
 
   describe '#generate_linemax_64' do
@@ -35,28 +49,60 @@ RSpec.describe Rex::Exploitation::CmdStagerEcho do
   end
 
   describe '#generate_hex_double_quoted_linemax_32' do
-    it "returns an array of commands, double quoted, split to 32 byte chunks" do
-      result = cmd_stager.generate(linemax: 32,
-                                   enc_format: :hex_double_quoted)
+    it "returns an array of commands, encoded as hex, double quoted, split to 32 byte chunks" do
+      result = cmd_stager.generate(
+        linemax: 32,
+        enc_format: :hex_double_quoted
+      )
       expect(result).to be_kind_of(Array)
       expect(result).to_not be_empty
       expect(result.size).to be > 1
       expect(result[1].size).to be <= 32
-      # This is pretty specific to my starting exe value up there.
+      # This is specific to the test :exe
       expect(result[1]).to start_with('echo -en "\x41\x41">>/tmp/')
     end
   end
 
   describe '#generate_hex_single_quoted_linemax_32' do
-    it "returns an array of commands, single quoted, split to 32 byte chunks" do
-      result = cmd_stager.generate(linemax: 32,
-                                   enc_format: :hex_single_quoted)
+    it "returns an array of commands, encoded as hex, single quoted, split to 32 byte chunks" do
+      result = cmd_stager.generate(
+        linemax: 32,
+        enc_format: :hex_single_quoted
+      )
       expect(result).to be_kind_of(Array)
       expect(result).to_not be_empty
       expect(result.size).to be > 1
       expect(result[1].size).to be <= 32
-      # This is pretty specific to my starting exe value up there.
+      # This is specific to the test :exe
       expect(result[1]).to start_with("echo -en '\\x41\\x41'>>/tmp/")
+    end
+  end
+
+  describe '#generate_octal_linemax_32' do
+    it "returns an array of commands, encoded as octal, without quotes, split to 32 byte chunks" do
+      result = cmd_stager.generate(
+        linemax: 32,
+        enc_format: :octal
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+      expect(result.size).to be > 1
+      expect(result[1].size).to be <= 32
+      # This is specific to the test :exe
+      expect(result[1]).to start_with("echo -en \\\\101\\\\101>>/tmp/")
+    end
+  end
+
+  describe '#generate_nodelete' do
+    it "returns an array of commands without rm" do
+      result = cmd_stager.generate(nodelete: true)
+
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+
+      for command in result
+        expect(command).to_not include('rm -f ')
+      end
     end
   end
 

--- a/spec/lib/rex/exploitation/cmdstager/fetch_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/fetch_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe Rex::Exploitation::CmdStagerFetch do
     described_class.new(exe)
   end
 
+  describe "#http?" do
+    it "returns true" do
+      expect(cmd_stager.http?)
+    end
+  end
+
+  describe "#user_agent" do
+    it "returns a known user agent match" do
+      expect(cmd_stager.user_agent).to be_kind_of(Regexp)
+    end
+  end
+
   describe '#cmd_concat_operator' do
     it "returns ;" do
       expect(cmd_stager.cmd_concat_operator).to eq(';')
@@ -18,13 +30,19 @@ RSpec.describe Rex::Exploitation::CmdStagerFetch do
   end
 
   describe '#generate' do
+    it "raises when missing :payload_uri" do
+      expect { cmd_stager.generate }.to raise_error(StandardError)
+    end
+
     it "returns an array of commands" do
       result = cmd_stager.generate(payload_uri: "http://127.0.0.1/#{Rex::Text.rand_text_alphanumeric(10)}")
 
       expect(result).to be_kind_of(Array)
       expect(result).to_not be_empty
     end
+  end
 
+  describe '#generate_nospace' do
     it "returns an array of commands without spaces" do
       result = cmd_stager.generate(
         payload_uri: "http://127.0.0.1/#{Rex::Text.rand_text_alphanumeric(10)}",
@@ -36,6 +54,22 @@ RSpec.describe Rex::Exploitation::CmdStagerFetch do
 
       for command in result
         expect(command).to_not include(' ')
+      end
+    end
+  end
+
+  describe '#generate_nodelete' do
+    it "returns an array of commands without rm" do
+      result = cmd_stager.generate(
+        payload_uri: "http://127.0.0.1/#{Rex::Text.rand_text_alphanumeric(10)}",
+        nodelete: true
+      )
+
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+
+      for command in result
+        expect(command).to_not include('rm -f ')
       end
     end
   end

--- a/spec/lib/rex/exploitation/cmdstager/ftp_http_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/ftp_http_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe Rex::Exploitation::CmdStagerFtpHttp do
     described_class.new(exe)
   end
 
+  describe "#http?" do
+    it "returns true" do
+      expect(cmd_stager.http?)
+    end
+  end
+
+  describe "#user_agent" do
+    it "returns a known user agent match" do
+      expect(cmd_stager.user_agent).to be_kind_of(Regexp)
+    end
+  end
+
   describe '#cmd_concat_operator' do
     it "returns ;" do
       expect(cmd_stager.cmd_concat_operator).to eq(';')
@@ -18,13 +30,19 @@ RSpec.describe Rex::Exploitation::CmdStagerFtpHttp do
   end
 
   describe '#generate' do
+    it "raises when missing :payload_uri" do
+      expect { cmd_stager.generate }.to raise_error(StandardError)
+    end
+
     it "returns an array of commands" do
       result = cmd_stager.generate(payload_uri: "http://127.0.0.1/#{Rex::Text.rand_text_alphanumeric(10)}")
 
       expect(result).to be_kind_of(Array)
       expect(result).to_not be_empty
     end
+  end
 
+  describe '#generate_nospace' do
     it "returns an array of commands without spaces" do
       result = cmd_stager.generate(
         payload_uri: "http://127.0.0.1/#{Rex::Text.rand_text_alphanumeric(10)}",
@@ -36,6 +54,22 @@ RSpec.describe Rex::Exploitation::CmdStagerFtpHttp do
 
       for command in result
         expect(command).to_not include(' ')
+      end
+    end
+  end
+
+  describe '#generate_nodelete' do
+    it "returns an array of commands without rm" do
+      result = cmd_stager.generate(
+        payload_uri: "http://127.0.0.1/#{Rex::Text.rand_text_alphanumeric(10)}",
+        nodelete: true
+      )
+
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+
+      for command in result
+        expect(command).to_not include('rm -f ')
       end
     end
   end

--- a/spec/lib/rex/exploitation/cmdstager/lwprequest_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/lwprequest_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe Rex::Exploitation::CmdStagerLwpRequest do
     described_class.new(exe)
   end
 
+  describe "#http?" do
+    it "returns true" do
+      expect(cmd_stager.http?)
+    end
+  end
+
+  describe "#user_agent" do
+    it "returns a known user agent match" do
+      expect(cmd_stager.user_agent).to be_kind_of(Regexp)
+    end
+  end
+
   describe '#cmd_concat_operator' do
     it "returns ;" do
       expect(cmd_stager.cmd_concat_operator).to eq(';')
@@ -18,13 +30,19 @@ RSpec.describe Rex::Exploitation::CmdStagerLwpRequest do
   end
 
   describe '#generate' do
+    it "raises when missing :payload_uri" do
+      expect { cmd_stager.generate }.to raise_error(StandardError)
+    end
+
     it "returns an array of commands" do
       result = cmd_stager.generate(payload_uri: "http://127.0.0.1/#{Rex::Text.rand_text_alphanumeric(10)}")
 
       expect(result).to be_kind_of(Array)
       expect(result).to_not be_empty
     end
+  end
 
+  describe '#generate_nospace' do
     it "returns an array of commands without spaces" do
       result = cmd_stager.generate(
         payload_uri: "http://127.0.0.1/#{Rex::Text.rand_text_alphanumeric(10)}",
@@ -36,6 +54,22 @@ RSpec.describe Rex::Exploitation::CmdStagerLwpRequest do
 
       for command in result
         expect(command).to_not include(' ')
+      end
+    end
+  end
+
+  describe '#generate_nodelete' do
+    it "returns an array of commands without rm" do
+      result = cmd_stager.generate(
+        payload_uri: "http://127.0.0.1/#{Rex::Text.rand_text_alphanumeric(10)}",
+        nodelete: true
+      )
+
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+
+      for command in result
+        expect(command).to_not include('rm -f ')
       end
     end
   end

--- a/spec/lib/rex/exploitation/cmdstager/printf_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/printf_spec.rb
@@ -26,4 +26,45 @@ RSpec.describe Rex::Exploitation::CmdStagerPrintf do
     end
   end
 
+  describe '#generate_linemax_too_small' do
+    it "raises when :linemax is too small to contain min_part_size" do
+      expect {
+        cmd_stager.generate(linemax: 5)
+      }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe '#generate_linemax_64' do
+    it "returns an array of commands, split to 64 byte chunks" do
+      result = cmd_stager.generate(linemax: 64)
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+      expect(result.size).to be > 1
+    end
+  end
+
+  describe '#generate_nodelete' do
+    it "returns an array of commands without rm" do
+      result = cmd_stager.generate(nodelete: true)
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+
+      for command in result
+        expect(command).to_not include('rm -f ')
+      end
+    end
+  end
+
+  describe '#generate_noquotes' do
+    it "returns an array of commands without quotes" do
+      result = cmd_stager.generate(noquotes: true)
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+
+      for command in result
+        expect(command).to_not include("'")
+      end
+    end
+  end
+
 end

--- a/spec/lib/rex/exploitation/cmdstager/psh_invokewebrequest_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/psh_invokewebrequest_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe Rex::Exploitation::CmdStagerPSHInvokeWebRequest do
     described_class.new(exe)
   end
 
+  describe "#http?" do
+    it "returns true" do
+      expect(cmd_stager.http?)
+    end
+  end
+
+  describe "#user_agent" do
+    it "returns a known user agent match" do
+      expect(cmd_stager.user_agent).to be_kind_of(Regexp)
+    end
+  end
+
   describe '#cmd_concat_operator' do
     it "returns &" do
       expect(cmd_stager.cmd_concat_operator).to eq(' & ')
@@ -18,11 +30,31 @@ RSpec.describe Rex::Exploitation::CmdStagerPSHInvokeWebRequest do
   end
 
   describe '#generate' do
+    it "raises when missing :payload_uri" do
+      expect { cmd_stager.generate }.to raise_error(StandardError)
+    end
+
     it "returns an array of commands" do
       result = cmd_stager.generate(payload_uri: "http://127.0.0.1/#{Rex::Text.rand_text_alphanumeric(10)}")
 
       expect(result).to be_kind_of(Array)
       expect(result).to_not be_empty
+    end
+  end
+
+  describe '#generate_nodelete' do
+    it "returns an array of commands without del" do
+      result = cmd_stager.generate(
+        payload_uri: "http://127.0.0.1/#{Rex::Text.rand_text_alphanumeric(10)}",
+        nodelete: true
+      )
+
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+
+      for command in result
+        expect(command).to_not include('del ')
+      end
     end
   end
 

--- a/spec/lib/rex/exploitation/cmdstager/tftp_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/tftp_spec.rb
@@ -18,11 +18,31 @@ RSpec.describe Rex::Exploitation::CmdStagerTFTP do
   end
 
   describe '#generate' do
+    it "raises when missing :tftphost" do
+      expect { cmd_stager.generate }.to raise_error(StandardError)
+    end
+
     it "returns an array of commands" do
       result = cmd_stager.generate(tftphost: '0.0.0.0')
 
       expect(result).to be_kind_of(Array)
       expect(result).to_not be_empty
+    end
+  end
+
+  describe '#generate_nodelete' do
+    it "returns an array of commands without del" do
+      result = cmd_stager.generate(
+        tftphost: '0.0.0.0',
+        nodelete: true
+      )
+
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+
+      for command in result
+        expect(command).to_not include('del ')
+      end
     end
   end
 

--- a/spec/lib/rex/exploitation/cmdstager/vbs_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/vbs_spec.rb
@@ -32,4 +32,20 @@ RSpec.describe Rex::Exploitation::CmdStagerVBS do
     end
   end
 
+  describe '#generate_nodelete' do
+    it "returns an array of commands without del" do
+      result = cmd_stager.generate(
+        decoder: File.join(Rex::Exploitation::DATA_DIR, "exploits", "cmdstager", "vbs_b64"),
+        nodelete: true
+      )
+
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+
+      for command in result
+        expect(command).to_not include('del ')
+      end
+    end
+  end
+
 end

--- a/spec/lib/rex/exploitation/cmdstager/wget_spec.rb
+++ b/spec/lib/rex/exploitation/cmdstager/wget_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe Rex::Exploitation::CmdStagerWget do
     described_class.new(exe)
   end
 
+  describe "#http?" do
+    it "returns true" do
+      expect(cmd_stager.http?)
+    end
+  end
+
+  describe "#user_agent" do
+    it "returns a known user agent match" do
+      expect(cmd_stager.user_agent).to be_kind_of(Regexp)
+    end
+  end
+
   describe '#cmd_concat_operator' do
     it "returns ;" do
       expect(cmd_stager.cmd_concat_operator).to eq(';')
@@ -18,13 +30,19 @@ RSpec.describe Rex::Exploitation::CmdStagerWget do
   end
 
   describe '#generate' do
+    it "raises when missing :payload_uri" do
+      expect { cmd_stager.generate }.to raise_error(StandardError)
+    end
+
     it "returns an array of commands" do
       result = cmd_stager.generate(payload_uri: "http://127.0.0.1/#{Rex::Text.rand_text_alphanumeric(10)}")
 
       expect(result).to be_kind_of(Array)
       expect(result).to_not be_empty
     end
+  end
 
+  describe '#generate_nospace' do
     it "returns an array of commands without spaces" do
       result = cmd_stager.generate(
         payload_uri: "http://127.0.0.1/#{Rex::Text.rand_text_alphanumeric(10)}",
@@ -36,6 +54,22 @@ RSpec.describe Rex::Exploitation::CmdStagerWget do
 
       for command in result
         expect(command).to_not include(' ')
+      end
+    end
+  end
+
+  describe '#generate_nodelete' do
+    it "returns an array of commands without rm" do
+      result = cmd_stager.generate(
+        payload_uri: "http://127.0.0.1/#{Rex::Text.rand_text_alphanumeric(10)}",
+        nodelete: true
+      )
+
+      expect(result).to be_kind_of(Array)
+      expect(result).to_not be_empty
+
+      for command in result
+        expect(command).to_not include('rm -f ')
       end
     end
   end

--- a/spec/lib/rex/exploitation/egghunter_spec.rb
+++ b/spec/lib/rex/exploitation/egghunter_spec.rb
@@ -8,4 +8,263 @@ RSpec.describe Rex::Exploitation::Egghunter do
       expect(described_class.new("x86")).to be_a(Rex::Exploitation::Egghunter)
     end
   end
+
+  describe '#generate' do
+    it 'returns an array containing Windows X86 egg hunter' do
+      payload = 'hello'
+      badchars = ''
+      eggtag = 'w00t'
+      result = described_class.new('win', Rex::Arch::ARCH_X86).generate(
+        payload,
+        badchars,
+        eggtag: eggtag,
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result.size).to be 2
+
+      egghunter = result[0]
+      expect(egghunter).to include(eggtag)
+
+      egg = result[1]
+      expect(egg).to include(eggtag + payload)
+    end
+
+    it 'returns an array containing Windows X86 egg hunter with no bad characters' do
+      payload = 'hello'
+      badchars = "\x00\x0a\x0d"
+      eggtag = 'w00t'
+      result = described_class.new('win', Rex::Arch::ARCH_X86).generate(
+        payload,
+        badchars,
+        eggtag: eggtag,
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result.size).to be 2
+
+      egghunter = result[0]
+      expect(egghunter).to include(eggtag)
+
+      egg = result[1]
+      expect(egg).to include(eggtag + payload)
+
+      badchars.each_char do |c|
+        expect(egg).to_not include(c)
+      end
+    end
+
+    it 'returns an array containing Windows X86 egg hunter starting search from eax register' do
+      payload = 'hello'
+      badchars = ''
+      eggtag = 'w00t'
+      result = described_class.new('win', Rex::Arch::ARCH_X86).generate(
+        payload,
+        badchars,
+        eggtag: eggtag,
+        startreg: 'eax',
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result.size).to be 2
+
+      egghunter = result[0]
+      expect(egghunter).to include(eggtag)
+
+      egg = result[1]
+      expect(egg).to include(eggtag + payload)
+    end
+
+    it 'returns an array containing Windows X86 egg hunter with checksum' do
+      payload = 'hello'
+      badchars = ''
+      eggtag = 'w00t'
+      result = described_class.new('win', Rex::Arch::ARCH_X86).generate(
+        payload,
+        badchars,
+        eggtag: eggtag,
+        checksum: true,
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result.size).to be 2
+
+      egghunter = result[0]
+      expect(egghunter).to include(eggtag)
+
+      egg = result[1]
+      expect(egg).to include(eggtag + payload)
+    end
+
+    it 'returns an array containing Windows X86 egg hunter using virtualalloc :depmethod' do
+      payload = 'hello'
+      badchars = ''
+      eggtag = 'w00t'
+      result = described_class.new('win', Rex::Arch::ARCH_X86).generate(
+        payload,
+        badchars,
+        eggtag: eggtag,
+        depmethod: 'virtualalloc',
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result.size).to be 2
+
+      egghunter = result[0]
+      expect(egghunter).to include(eggtag)
+
+      egg = result[1]
+      expect(egg).to include(eggtag + payload)
+    end
+
+    it 'returns an array containing Windows X86 egg hunter using virtualprotect :depmethod' do
+      payload = 'hello'
+      badchars = ''
+      eggtag = 'w00t'
+      result = described_class.new('win', Rex::Arch::ARCH_X86).generate(
+        payload,
+        badchars,
+        eggtag: eggtag,
+        depmethod: 'virtualprotect',
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result.size).to be 2
+
+      egghunter = result[0]
+      expect(egghunter).to include(eggtag)
+
+      egg = result[1]
+      expect(egg).to include(eggtag + payload)
+    end
+
+    it 'returns an array containing Windows X86 egg hunter using copy :depmethod' do
+      payload = 'hello'
+      badchars = ''
+      eggtag = 'w00t'
+      result = described_class.new('win', Rex::Arch::ARCH_X86).generate(
+        payload,
+        badchars,
+        eggtag: eggtag,
+        depmethod: 'copy',
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result.size).to be 2
+
+      egghunter = result[0]
+      expect(egghunter).to include(eggtag)
+
+      egg = result[1]
+      expect(egg).to include(eggtag + payload)
+    end
+
+    it 'returns an array containing Windows X86 egg hunter using copy_size :depmethod' do
+      payload = 'hello'
+      badchars = ''
+      eggtag = 'w00t'
+      result = described_class.new('win', Rex::Arch::ARCH_X86).generate(
+        payload,
+        badchars,
+        eggtag: eggtag,
+        depmethod: 'copy_size',
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result.size).to be 2
+
+      egghunter = result[0]
+      expect(egghunter).to include(eggtag)
+
+      egg = result[1]
+      expect(egg).to include(eggtag + payload)
+    end
+
+    it 'returns an array containing Linux X86 egg hunter' do
+      payload = 'hello'
+      badchars = ''
+      eggtag = 'w00t'
+      result = described_class.new('linux', Rex::Arch::ARCH_X86).generate(
+        payload,
+        badchars,
+        eggtag: eggtag,
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result.size).to be 2
+
+      egghunter = result[0]
+      expect(egghunter).to include(eggtag)
+
+      egg = result[1]
+      expect(egg).to include(eggtag + payload)
+    end
+
+    it 'returns an array containing Linux X86 egg hunter starting search from eax register' do
+      payload = 'hello'
+      badchars = ''
+      eggtag = 'w00t'
+      result = described_class.new('linux', Rex::Arch::ARCH_X86).generate(
+        payload,
+        badchars,
+        eggtag: eggtag,
+        startreg: 'eax',
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result.size).to be 2
+
+      egghunter = result[0]
+      expect(egghunter).to include(eggtag)
+
+      egg = result[1]
+      expect(egg).to include(eggtag + payload)
+    end
+
+    it 'returns an array containing Linux X86 egg hunter with no bad characters' do
+      payload = 'hello'
+      badchars = "\x00\x0a\x0d"
+      eggtag = 'w00t'
+      result = described_class.new('linux', Rex::Arch::ARCH_X86).generate(
+        payload,
+        badchars,
+        eggtag: eggtag,
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result.size).to be 2
+
+      egghunter = result[0]
+      expect(egghunter).to include(eggtag)
+
+      egg = result[1]
+      expect(egg).to include(eggtag + payload)
+
+      badchars.each_char do |c|
+        expect(egg).to_not include(c)
+      end
+    end
+
+    it 'returns an array containing Linux X86 egg hunter with checksum' do
+      payload = 'hello'
+      badchars = ''
+      eggtag = 'w00t'
+      result = described_class.new('linux', Rex::Arch::ARCH_X86).generate(
+        payload,
+        badchars,
+        eggtag: eggtag,
+        checksum: true,
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result.size).to be 2
+
+      egghunter = result[0]
+      expect(egghunter).to include(eggtag)
+
+      egg = result[1]
+      expect(egg).to include(eggtag + payload)
+    end
+
+    it 'raises when calculating checksum for payload exceeding 0x10000 bytes in length' do
+      payload = 'A' * 0x10000
+      badchars = ''
+      expect {
+        described_class.new('win', Rex::Arch::ARCH_X86).generate(
+          payload,
+          badchars,
+          checksum: true,
+        )
+      }.to raise_error(RuntimeError)
+    end
+  end
+
 end

--- a/spec/lib/rex/exploitation/js/memory_spec.rb
+++ b/spec/lib/rex/exploitation/js/memory_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe Rex::Exploitation::Js::Memory do
       end
     end
 
+    context ".heaplib2" do
+      it "should load the heaplib2 javascript" do
+        js = Rex::Exploitation::Js::Memory.heaplib2.to_s
+        expect(js).to match /function /
+      end
+
+      it "should load the heaplib2 javascript with custom javascript" do
+        js = Rex::Exploitation::Js::Memory.heaplib2(";var test = 123;").to_s
+        expect(js).to match /function /
+      end
+    end
+
     context ".property_spray" do
       it "should load the property_spray javascript" do
         js = Rex::Exploitation::Js::Memory.property_spray
@@ -22,6 +34,25 @@ RSpec.describe Rex::Exploitation::Js::Memory do
       it "should load the heap_spray javascript" do
         js = Rex::Exploitation::Js::Memory.heap_spray
         expect(js).to match /function sprayHeap/
+      end
+    end
+
+    context ".explib2" do
+      it "should load the explib2 javascript" do
+        js = Rex::Exploitation::Js::Memory.explib2
+        expect(js).to match /function ExpLib/
+      end
+    end
+
+    context ".explib2_payload" do
+      it "should load the explib2 exec payload javascript" do
+        js = Rex::Exploitation::Js::Memory.explib2_payload('exec')
+        expect(js).to match /function payload_exec/
+      end
+
+      it "should load the explib2 drop_exec payload javascript" do
+        js = Rex::Exploitation::Js::Memory.explib2_payload('drop_exec')
+        expect(js).to match /function payload_drop_exec/
       end
     end
 

--- a/spec/lib/rex/exploitation/jsobfu_spec.rb
+++ b/spec/lib/rex/exploitation/jsobfu_spec.rb
@@ -3,6 +3,8 @@ require 'rex/exploitation/jsobfu'
 
 RSpec.describe Rex::Exploitation::JSObfu do
   TEST_JS = %Q|
+    var test = 123;
+
     function x() {
       alert('1');
     };
@@ -15,7 +17,6 @@ RSpec.describe Rex::Exploitation::JSObfu do
   end
 
   describe '#obfuscate' do
-    
     it 'returns a #to_s object' do
       expect(jsobfu.obfuscate.to_s).to be_a(String)
     end
@@ -23,7 +24,14 @@ RSpec.describe Rex::Exploitation::JSObfu do
     it 'returns a non-empty String' do
       expect(jsobfu.obfuscate.to_s).not_to be_empty
     end
+  end
 
+  describe '#sym' do
+    it 'returns an obfuscated JavaScript variable name' do
+      result = jsobfu.obfuscate
+      expect(result.sym('test')).not_to be_empty
+      expect(result.sym('test')).to be_a(String)
+    end
   end
 
 end

--- a/spec/lib/rex/exploitation/omelet_spec.rb
+++ b/spec/lib/rex/exploitation/omelet_spec.rb
@@ -8,4 +8,98 @@ RSpec.describe Rex::Exploitation::Omelet do
       expect(described_class.new("x86")).to be_a(Rex::Exploitation::Omelet)
     end
   end
+
+  describe '#generate' do
+    it 'returns an array containing Windows X86 omelet hunter' do
+      payload = 'hello'
+      badchars = ''
+      eggtag = '00w'
+      result = described_class.new('win', Rex::Arch::ARCH_X86).generate(
+        payload,
+        badchars,
+        eggtag: eggtag,
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result.size).to be 2
+
+      omelete = result[0]
+      expect(omelete).to include(eggtag)
+
+      eggs = result[1]
+      expect(eggs).to be_kind_of(Array)
+      expect(eggs.size).to be 1
+      expect(eggs.first).to include(eggtag + payload)
+    end
+
+    it 'returns an array containing Windows X86 omelet hunter with no bad characters' do
+      payload = 'hello'
+      badchars = "\x00\x0a\x0d"
+      eggtag = '00w'
+      result = described_class.new('win', Rex::Arch::ARCH_X86).generate(
+        payload,
+        badchars,
+        eggtag: eggtag,
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result.size).to be 2
+
+      omelete = result[0]
+      expect(omelete).to include(eggtag)
+
+      eggs = result[1]
+      expect(eggs).to be_kind_of(Array)
+      expect(eggs.size).to be 1
+      expect(eggs.first).to include(eggtag + payload)
+      for egg in eggs
+        badchars.each_char do |c|
+          expect(egg).to_not include(c)
+        end
+      end
+    end
+
+    it 'returns an array containing Windows X86 omelet hunter starting search from eax register' do
+      payload = 'hello'
+      badchars = ''
+      eggtag = '00w'
+      result = described_class.new('win', Rex::Arch::ARCH_X86).generate(
+        payload,
+        badchars,
+        eggtag: eggtag,
+        startreg: 'eax',
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result.size).to be 2
+
+      omelete = result[0]
+      expect(omelete).to include(eggtag)
+
+      eggs = result[1]
+      expect(eggs).to be_kind_of(Array)
+      expect(eggs.size).to be 1
+      expect(eggs.first).to include(eggtag + payload)
+    end
+
+    it 'returns an array containing Windows X86 omelet hunter with checksum' do
+      payload = 'hello'
+      badchars = ''
+      eggtag = '00w'
+      result = described_class.new('win', Rex::Arch::ARCH_X86).generate(
+        payload,
+        badchars,
+        eggtag: eggtag,
+        checksum: true,
+      )
+      expect(result).to be_kind_of(Array)
+      expect(result.size).to be 2
+
+      omelete = result[0]
+      expect(omelete).to include(eggtag)
+
+      eggs = result[1]
+      expect(eggs).to be_kind_of(Array)
+      expect(eggs.size).to be 1
+      expect(eggs.first).to include(eggtag + payload)
+    end
+  end
+
 end


### PR DESCRIPTION
Increases test code coverage from ~77% to ~94%, at the expense of increasing the test duration from ~0.25 seconds to ~1.30 seconds.

Test coverage is now above 80% for all files, except the `obfuscatejs` JavaScript obfuscation library. I've left the JS obfuscation libraries alone (mostly). The libraries themselves may require some rework.

The JS related libraries in `rex-exploitation` appear to use a mishmash of both of `jsobfu` and `obfuscatejs`.

There are a small number of tests for [lib/rex/exploitation/jsobfu.rb](https://github.com/rapid7/rex-exploitation/blob/master/lib/rex/exploitation/jsobfu.rb) which require the [rapid7/jsobfu](https://github.com/rapid7/jsobfu/) Ruby gem external dependency (which has been archived and appears to no longer be supported).

No tests exist for [lib/rex/exploitation/obfuscatejs.rb](https://github.com/rapid7/rex-exploitation/blob/master/lib/rex/exploitation/obfuscatejs.rb) and it hasn't been updated in 6 years.

To run the tests with code coverage, apply the following diff:

```diff
diff --git a/spec/spec_helper.rb b/spec/spec_helper.rb
index 23ad9d9..2b70a4f 100644
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,5 @@
+require 'simplecov'
+SimpleCov.start
+
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "rex/exploitation"
```


# Before

```
Finished in 0.24858 seconds (files took 0.37901 seconds to load)
72 examples, 0 failures

Coverage report generated for RSpec to /root/Desktop/rex-exploitation/coverage. 1288 / 1661 LOC (77.54%) covered.
```

# After

```
Finished in 1.29 seconds (files took 0.40318 seconds to load)
137 examples, 0 failures

Coverage report generated for RSpec to /root/Desktop/rex-exploitation/coverage. 1957 / 2080 LOC (94.09%) covered.
```
