### PR TITLE
Updates verify workflow to use shared pipeline

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,44 +9,5 @@ on:
       - '*'
 
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
-
-    strategy:
-      fail-fast: true
-      matrix:
-        ruby:
-          - '2.7'
-          - '3.0'
-          - '3.1'
-          - '3.2'
-        os:
-          - ubuntu-20.04
-          - ubuntu-latest
-        exclude:
-          - { os: ubuntu-latest, ruby: '2.7' }
-          - { os: ubuntu-latest, ruby: '3.0' }
-        test_cmd:
-          - bundle exec rspec
-
-    env:
-      RAILS_ENV: test
-
-    name: ${{ matrix.os }} - Ruby ${{ matrix.ruby }} - ${{ matrix.test_cmd }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-
-      - name: ${{ matrix.test_cmd }}
-        run: |
-          echo "${CMD}"
-          bash -c "${CMD}"
-        env:
-          CMD: ${{ matrix.test_cmd }}
+  build:
+    uses: rapid7/metasploit-framework/.github/workflows/shared_gem_verify.yml@master

--- a/rex-exploitation.gemspec
+++ b/rex-exploitation.gemspec
@@ -34,4 +34,12 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'metasm'
   # Needed for Javascript obfuscation
   spec.add_runtime_dependency 'jsobfu'
+
+  # bigdecimal and racc are not part of the default gems starting from Ruby 3.4.0: https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
+  %w[
+    bigdecimal
+    racc
+  ].each do |library|
+    spec.add_runtime_dependency library
+  end
 end


### PR DESCRIPTION
This updates this workflow to make use off the shared pipeline added as part of https://github.com/rapid7/metasploit-framework/pull/20001.

Initially this PR will point at these new pipelines on my @cgranleese-r7 repository for testing. Once this is landed, I will rebase this PR.

Related PRs:
- https://github.com/rapid7/metasploit-framework/pull/20001
- https://github.com/rapid7/metasploit-concern/pull/45
- https://github.com/rapid7/metasploit-credential/pull/189
- https://github.com/rapid7/metasploit-model/pull/73
- https://github.com/rapid7/metasploit_data_models/pull/216
- https://github.com/rapid7/rex-core/pull/43
- https://github.com/rapid7/rex-exploitation/pull/46/
- https://github.com/rapid7/rex-mime/pull/9
- https://github.com/rapid7/rex-powershell/pull/45
- https://github.com/rapid7/rex-random_identifier/pull/15
- https://github.com/rapid7/rex-socket/pull/73
- https://github.com/rapid7/rex-sslscan/pull/10
- https://github.com/rapid7/rex-text/pull/73

## Ruby 3.4
I also added bigdecimal and racc to the gemspec as it is not part of the default gems starting from Ruby 3.4.0(https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/). This can be pulled out into another PR if that is preferred.

## Verification

- [ ] Ensure CI passes
- [ ] Testing output flows as expected